### PR TITLE
Fix compile on redox

### DIFF
--- a/src/sys.rs
+++ b/src/sys.rs
@@ -36,10 +36,10 @@ impl Error {
 /// Cooperatively gives up a timeslice to the OS scheduler.
 pub fn yield_now() {
     unsafe {
-        #[cfg(unix)]
+        #[cfg(target_os = "redox")]
         syscall!(SCHED_YIELD);
 
-        #[cfg(redox)]
+        #[cfg(not(target_os = "redox")]
         ::system::syscall::unix::sys_yield();
     }
 }


### PR DESCRIPTION
Redox still sets cfg(unix), this is a cfg that will fix compile issues on Redox
(yes, this does mean I am switching the allocator)