### PR TITLE
Fix the iterator moving left in find

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -63,6 +63,24 @@ impl Block {
         }
     }
 
+    /// Create an empty block representing the left edge of this block
+    #[inline]
+    pub fn empty_left(&self) -> Block {
+        Block {
+            size: 0,
+            ptr: unsafe { Pointer::new(*self.ptr) },
+        }
+    }
+
+    /// Create an empty block representing the right edge of this block
+    #[inline]
+    pub fn empty_right(&self) -> Block {
+        Block {
+            size: 0,
+            ptr: unsafe { Pointer::new(*self.ptr).offset(self.size as isize) },
+        }
+    }
+
     /// Merge this block with a block to the right.
     ///
     /// This will simply extend the block, adding the size of the block, and then set the size to

--- a/src/bookkeeper.rs
+++ b/src/bookkeeper.rs
@@ -564,15 +564,21 @@ impl Bookkeeper {
     ///
     /// It is guaranteed that no block left to the returned value, satisfy the above condition.
     #[inline]
-    fn find(&self, block: &Block) -> usize {
+    fn find(&mut self, block: &Block) -> usize {
         // TODO optimize this function.
 
         let ind = match self.pool.binary_search(block) {
             Ok(x) | Err(x) => x,
         };
+        let len = self.pool.len();
 
         // Move left.
-        ind - self.pool.iter().skip(ind + 1).rev().take_while(|x| x.is_empty()).count()
+        ind - self.pool.iter_mut()
+            .rev()
+            .skip(len - ind)
+            .take_while(|x| x.is_empty())
+            .map(|x| *x = block.empty_left())
+            .count()
     }
 
     /// Insert a block entry at some index.


### PR DESCRIPTION
Set each empty block passed to the left edge of the block being inserted