### PR TITLE
Check if reserve changed pool before pushing (#31)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
         single_match_else, string_add, string_add_assign, wrong_pub_self_convention)]
 
 #[macro_use]
+#[no_link]
 extern crate unborrow;
 
 #[cfg(feature = "write")]

--- a/tests/scaling.rs
+++ b/tests/scaling.rs
@@ -3,7 +3,6 @@ extern crate ralloc;
 mod util;
 
 #[test]
-#[ignore]
 fn big_alloc() {
     util::multiply(|| {
         let mut vec = Vec::new();
@@ -19,7 +18,6 @@ fn big_alloc() {
 }
 
 #[test]
-#[ignore]
 fn many_small_allocs() {
     util::multiply(|| {
         let mut vec = Vec::new();

--- a/tests/too_many_threads.rs
+++ b/tests/too_many_threads.rs
@@ -22,7 +22,6 @@ fn make_thread() -> thread::JoinHandle<()> {
 }
 
 #[test]
-#[ignore]
 fn multithread_join_handle_vec() {
     util::multiply(|| {
         let mut join = Vec::new();


### PR DESCRIPTION
Reenable all tests
Don't link the macro only crate unborrow