### PR TITLE
add support for Linux on AArch64, MIPS(64), PowerPC(64) and SPARC64

### DIFF
--- a/shim/Cargo.toml
+++ b/shim/Cargo.toml
@@ -13,4 +13,4 @@ debug-assertions = false
 codegen-units = 1
 
 [dependencies]
-syscall = "0.2.1"
+sc = "0.1.0"

--- a/shim/src/lib.rs
+++ b/shim/src/lib.rs
@@ -12,7 +12,7 @@
 #![warn(missing_docs)]
 
 #[macro_use]
-extern crate syscall;
+extern crate sc;
 
 pub mod config;
 pub mod thread_destructor;


### PR DESCRIPTION
by switching from the syscall crate to the sc crate. The sc crate is a
fork of the syscall crate that adds supports for several other
platforms.

---

I have smoke tested ralloc (just `vec![1, 2, 3, 4]`) for the following targets:

- `aarch64-unknown-linux-gnu`

- `mips-unknown-linux-gnu`

- `mipsel-unknown-linux-gnu`

- `mips64-unknown-linux-gnuabi64`

- `mips64el-unknown-linux-gnuabi64`

- `powerpc-unknown-linux-gnu`

- `powerpc64-unknown-linux-gnu`

- `powerpc64le-unknown-linux-gnu`

using QEMU.